### PR TITLE
Removes comma to make JSON example valid.

### DIFF
--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -83,7 +83,6 @@ name              type   description
          "is_confirmed": true,
          "creation_time": "2000-07-25T13:50:04Z",
          "assigned_to": "user@bugzilla.org",
-         "flags": [],
          "alias": [],
          "cf_large_text": "",
          "groups": [],
@@ -95,7 +94,7 @@ name              type   description
          "cf_qa_list_4": "---",
          "keywords": [],
          "cc": [
-           "foo@bar.com",
+           "foo@bar.com"
          ],
          "see_also": [],
          "deadline": null,

--- a/docs/en/rst/api/core/v1/bug.rst
+++ b/docs/en/rst/api/core/v1/bug.rst
@@ -77,7 +77,7 @@ name              type   description
              "real_name": "Foo Bar",
              "name": "foo@bar.com",
              "email": "foo@bar.com"
-           },
+           }
          ],
          "priority": "P1",
          "is_confirmed": true,


### PR DESCRIPTION
Current example response to GET /rest/bug/35 has a comma after the last item in an array.